### PR TITLE
Tied deployment node version to .nvmrc

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  NODE_VERSION: 22.19.0
-
 jobs:
   staging-deployment:
     runs-on: ubuntu-latest
@@ -19,7 +16,7 @@ jobs:
       - name: Configure node
         uses: actions/setup-node@v6.0.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: .nvmrc
 
       - name: Install packages
         run: npm ci
@@ -48,7 +45,7 @@ jobs:
       - name: Configure node
         uses: actions/setup-node@v6.0.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: .nvmrc
 
       - name: Install packages
         run: npm ci


### PR DESCRIPTION
Replaced the hardcoded NODE_VERSION env var with setup-node's
node-version-file option pointing at .nvmrc, so the workflow's
Node version stays in sync with the repo's declared version.

Co-Authored-By: Claude <noreply@anthropic.com>
